### PR TITLE
avoid repeating to build SIF image for Singularity: use local SIF image if an env variable LOCAL_SIF_PATH is set 

### DIFF
--- a/R/pull_image.R
+++ b/R/pull_image.R
@@ -14,7 +14,11 @@ pull_container <- function(container_id) {
     processx::run("docker", c("pull", container_id), echo = TRUE)
 
   } else if (config$backend == "singularity") {
-    processx::run("singularity", c("exec", paste0("docker://", container_id), "echo", "hi"), echo_cmd = TRUE, echo = FALSE)
+    local_sif_path <- Sys.getenv("LOCAL_SIF_PATH")
+    container_sif <- paste0(local_sif_path, "/", gsub("[/,:]", "_", container_id), ".sif")
+    if (!file.exists(container_sif)) {
+      processx::run("singularity", c("pull", container_sif, paste0("docker://", container_id)), echo_cmd = TRUE, echo = FALSE)  
+    }
   }
 
   return(TRUE)

--- a/R/pull_image.R
+++ b/R/pull_image.R
@@ -15,9 +15,13 @@ pull_container <- function(container_id) {
 
   } else if (config$backend == "singularity") {
     local_sif_path <- Sys.getenv("LOCAL_SIF_PATH")
-    container_sif <- paste0(local_sif_path, "/", gsub("[/,:]", "_", container_id), ".sif")
-    if (!file.exists(container_sif)) {
-      processx::run("singularity", c("pull", container_sif, paste0("docker://", container_id)), echo_cmd = TRUE, echo = FALSE)  
+    if (local_sif_path == "") { 
+      processx::run("singularity", c("exec", paste0("docker://", container_id), "echo", "hi"), echo_cmd = TRUE, echo = FALSE)
+    } else {
+      container_sif <- paste0(local_sif_path, "/", gsub("[/,:]", "_", container_id), ".sif")
+      if (!file.exists(container_sif)) {
+        processx::run("singularity", c("pull", container_sif, paste0("docker://", container_id)), echo_cmd = TRUE, echo = FALSE)  
+      }
     }
   }
 

--- a/R/run.R
+++ b/R/run.R
@@ -141,7 +141,9 @@ run <- function(
         )
       }
 
-    container <- paste0("docker://", container_id)
+    container_sif <- paste0("~/", gsub("[/,:]", "_", container_id), ".sif")
+    container <- container_sif
+    #container <- paste0("docker://", container_id)
 
     # determine command arguments
     processx_args <- c(

--- a/R/run.R
+++ b/R/run.R
@@ -141,7 +141,7 @@ run <- function(
         )
       }
 
-    container_sif <- paste0(gsub("[/,:]", "_", container_id), ".sif")
+    container_sif <- paste0(getwd(), "/", gsub("[/,:]", "_", container_id), ".sif")
     container <- container_sif
     #container <- paste0("docker://", container_id)
 

--- a/R/run.R
+++ b/R/run.R
@@ -141,7 +141,8 @@ run <- function(
         )
       }
 
-    container_sif <- paste0(getwd(), "/", gsub("[/,:]", "_", container_id), ".sif")
+    local_sif_path <- Sys.getenv("LOCAL_SIF_PATH")
+    container_sif <- paste0(local_sif_path, "/", gsub("[/,:]", "_", container_id), ".sif")
     container <- container_sif
     #container <- paste0("docker://", container_id)
 

--- a/R/run.R
+++ b/R/run.R
@@ -141,7 +141,7 @@ run <- function(
         )
       }
 
-    container_sif <- paste0("~/", gsub("[/,:]", "_", container_id), ".sif")
+    container_sif <- paste0(gsub("[/,:]", "_", container_id), ".sif")
     container <- container_sif
     #container <- paste0("docker://", container_id)
 

--- a/R/run.R
+++ b/R/run.R
@@ -142,9 +142,11 @@ run <- function(
       }
 
     local_sif_path <- Sys.getenv("LOCAL_SIF_PATH")
-    container_sif <- paste0(local_sif_path, "/", gsub("[/,:]", "_", container_id), ".sif")
-    container <- container_sif
-    #container <- paste0("docker://", container_id)
+    if (local_sif_path == "") {
+      container <- paste0("docker://", container_id)	
+    } else {
+      container <- paste0(local_sif_path, "/", gsub("[/,:]", "_", container_id), ".sif")
+    }
 
     # determine command arguments
     processx_args <- c(


### PR DESCRIPTION
When I run the program in the cluster with Singularity, I found that it takes a long time to build a SIF image. And for another run, it again takes a long time to build image, it seems that the cached image in `.singularity` folder does not help. Here is the running time (330s)

```r
> library(dyno)     
> x = matrix(rpois(9900, 1), nrow = 99)                                                                                                                                               
>     rownames(x) = 1:nrow(x)                                                                                                                                                         
>     colnames(x) = 1:ncol(x)                                                                                                                                                         
>     dataset = wrap_expression(counts = x, expression = log(x+1))     
> system.time({infer_trajectory(dataset, "comp1", debug=T)})                                                                                                                          
Running singularity exec 'docker://dynverse/ti_comp1:v0.9.9.01' echo hi
Running /usr/bin/singularity exec --containall -B \ 
  '/tmp/RtmpzcjE6q/file32c7f55a74b8e9/:/copy_mount,/tmp/RtmpzcjE6q/file32c7f541ac7236/tmp:/tmp2' \ 
  'docker://dynverse/ti_comp1:v0.9.9.01' cp /code/definition.yml /copy_mount/
Executing 'comp1' on '20231227_181629__data_wrapper__jSj89c7coa'        
With parameters: list(dimred = "pca", ndim = 2L, component = 1L) 
...
...
                                                                                                              
Running /usr/bin/singularity exec --containall --pwd /ti/workspace -B \
  '/tmp/RtmpzcjE6q/file32c7f542b877db/ti:/ti,/tmp/RtmpzcjE6q/file32c7f54c14b061/tmp:/tmp2' \
  'docker://dynverse/ti_comp1:v0.9.9.01' bash
INFO:    Converting OCI blobs to SIF format
INFO:    Starting build...
Getting image source signatures
Copying blob sha256:bd5da474b8baade003eb744e862574f758b269c20cd2bc0d3c6860e1b3b4e08a
Copying blob sha256:844c33c7e6ea19e3f6847e0667befdfb3ef02d6fc735b22c2d070261b6263b97
...
...

INFO:    Using cached SIF image      
   user  system elapsed 
309.030  12.012 330.661 

```

To avoid repeating to build the SIF image, I introduce an environment variable, `LOCAL_SIF_PATH`. If the variable is set, then **pull the image and save as `.sif` locally via**

```bash
singularity pull xxxx.sif docker://
```

To align with the existing code, if the env variable is unset, then just run as before.


After saving to a local SIF image, we can speed it up significantly --- only around 2 seconds for the same dataset.

```bash
devtools::install_github("szcf-weiya/babelwhale")
Sys.setenv(LOCAL_SIF_PATH=getwd())
```

![image](https://github.com/dynverse/babelwhale/assets/13688320/2874ab50-cfac-48c3-8a4c-c5e01cb3b86b)

```r
user  system elapsed
  0.865   0.663   1.952

```
